### PR TITLE
cockroach-go1.24.3: crypto: limit block size

### DIFF
--- a/src/crypto/internal/fips140/sha256/sha256.go
+++ b/src/crypto/internal/fips140/sha256/sha256.go
@@ -21,6 +21,10 @@ const size224 = 28
 // The block size of SHA-256 and SHA-224 in bytes.
 const blockSize = 64
 
+// The maximum number of bytes that can be passed to block().
+const maxAsmIters = 1024
+const maxAsmSize = blockSize * maxAsmIters // 64KiB
+
 const (
 	chunk     = 64
 	init0     = 0x6A09E667
@@ -172,6 +176,11 @@ func (d *Digest) Write(p []byte) (nn int, err error) {
 	}
 	if len(p) >= chunk {
 		n := len(p) &^ (chunk - 1)
+		for n > maxAsmSize {
+			block(d, p[:maxAsmSize])
+			p = p[maxAsmSize:]
+			n -= maxAsmSize
+		}
 		block(d, p[:n])
 		p = p[n:]
 	}

--- a/src/crypto/md5/md5.go
+++ b/src/crypto/md5/md5.go
@@ -28,6 +28,10 @@ const Size = 16
 // The blocksize of MD5 in bytes.
 const BlockSize = 64
 
+// The maximum number of bytes that can be passed to block.
+const maxAsmIters = 1024
+const maxAsmSize = BlockSize * maxAsmIters // 64KiB
+
 const (
 	init0 = 0x67452301
 	init1 = 0xEFCDAB89
@@ -138,6 +142,11 @@ func (d *digest) Write(p []byte) (nn int, err error) {
 	if len(p) >= BlockSize {
 		n := len(p) &^ (BlockSize - 1)
 		if haveAsm {
+			for n > maxAsmSize {
+				block(d, p[:maxAsmSize])
+				p = p[maxAsmSize:]
+				n -= maxAsmSize
+			}
 			block(d, p[:n])
 		} else {
 			blockGeneric(d, p[:n])

--- a/src/crypto/md5/md5_test.go
+++ b/src/crypto/md5/md5_test.go
@@ -133,10 +133,11 @@ func TestGoldenMarshal(t *testing.T) {
 
 func TestLarge(t *testing.T) {
 	const N = 10000
+	const offsets = 4
 	ok := "2bb571599a4180e1d542f76904adc3df" // md5sum of "0123456789" * 1000
-	block := make([]byte, 10004)
+	block := make([]byte, N+offsets)
 	c := New()
-	for offset := 0; offset < 4; offset++ {
+	for offset := 0; offset < offsets; offset++ {
 		for i := 0; i < N; i++ {
 			block[offset+i] = '0' + byte(i%10)
 		}
@@ -150,6 +151,31 @@ func TestLarge(t *testing.T) {
 			s := fmt.Sprintf("%x", c.Sum(nil))
 			if s != ok {
 				t.Fatalf("md5 TestLarge offset=%d, blockSize=%d = %s want %s", offset, blockSize, s, ok)
+			}
+		}
+	}
+}
+
+func TestExtraLarge(t *testing.T) {
+	const N = 100000
+	const offsets = 4
+	ok := "13572e9e296cff52b79c52148313c3a5" // md5sum of "0123456789" * 10000
+	block := make([]byte, N+offsets)
+	c := New()
+	for offset := 0; offset < offsets; offset++ {
+		for i := 0; i < N; i++ {
+			block[offset+i] = '0' + byte(i%10)
+		}
+		for blockSize := 10; blockSize <= N; blockSize *= 10 {
+			blocks := N / blockSize
+			b := block[offset : offset+blockSize]
+			c.Reset()
+			for i := 0; i < blocks; i++ {
+				c.Write(b)
+			}
+			s := fmt.Sprintf("%x", c.Sum(nil))
+			if s != ok {
+				t.Fatalf("md5 TestExtraLarge offset=%d, blockSize=%d = %s want %s", offset, blockSize, s, ok)
 			}
 		}
 	}

--- a/src/crypto/sha256/sha256_test.go
+++ b/src/crypto/sha256/sha256_test.go
@@ -200,6 +200,56 @@ func testGoldenMarshal(t *testing.T) {
 	}
 }
 
+func TestLarge(t *testing.T) {
+	const N = 10000
+	const offsets = 4
+	ok := "4c207598af7a20db0e3334dd044399a40e467cb81b37f7ba05a4f76dcbd8fd59" // sha256sum of "0123456789" * 1000
+	block := make([]byte, N+offsets)
+	c := New()
+	for offset := 0; offset < offsets; offset++ {
+		for i := 0; i < N; i++ {
+			block[offset+i] = '0' + byte(i%10)
+		}
+		for blockSize := 10; blockSize <= N; blockSize *= 10 {
+			blocks := N / blockSize
+			b := block[offset : offset+blockSize]
+			c.Reset()
+			for i := 0; i < blocks; i++ {
+				c.Write(b)
+			}
+			s := fmt.Sprintf("%x", c.Sum(nil))
+			if s != ok {
+				t.Fatalf("sha256 TestLarge offset=%d, blockSize=%d = %s want %s", offset, blockSize, s, ok)
+			}
+		}
+	}
+}
+
+func TestExtraLarge(t *testing.T) {
+	const N = 100000
+	const offsets = 4
+	ok := "aca9e593cc629cbaa94cd5a07dc029424aad93e5129e5d11f8dcd2f139c16cc0" // sha256sum of "0123456789" * 10000
+	block := make([]byte, N+offsets)
+	c := New()
+	for offset := 0; offset < offsets; offset++ {
+		for i := 0; i < N; i++ {
+			block[offset+i] = '0' + byte(i%10)
+		}
+		for blockSize := 10; blockSize <= N; blockSize *= 10 {
+			blocks := N / blockSize
+			b := block[offset : offset+blockSize]
+			c.Reset()
+			for i := 0; i < blocks; i++ {
+				c.Write(b)
+			}
+			s := fmt.Sprintf("%x", c.Sum(nil))
+			if s != ok {
+				t.Fatalf("sha256 TestExtraLarge offset=%d, blockSize=%d = %s want %s", offset, blockSize, s, ok)
+			}
+		}
+	}
+}
+
 func TestMarshalTypeMismatch(t *testing.T) {
 	h1 := New()
 	h2 := New224()


### PR DESCRIPTION
This change limits the amount of data that can be hashed at once - the assembly routines are not preemptible and can result in large latency outliers.


This is a port of https://github.com/cockroachdb/go/commit/34cd1ee45d9d926710ea0da43d9863606c982273 which didn't apply cleanly to 1.24. The sha256 implementation moved but the patch is otherwise the same.