### PR TITLE
cockroach: runtime: add grunningnanos

### DIFF
--- a/api/go1.txt
+++ b/api/go1.txt
@@ -30870,3 +30870,4 @@ pkg unicode/utf8, func RuneStart(uint8) bool
 pkg unicode/utf8, func Valid([]uint8) bool
 pkg unicode/utf8, func ValidString(string) bool
 pkg context, func PropagateCancel(Context, func()) bool
+pkg runtime, func Grunningnanos() int64

--- a/src/runtime/extern.go
+++ b/src/runtime/extern.go
@@ -89,6 +89,10 @@ It is a comma-separated list of name=val pairs setting these named variables:
 	making every garbage collection a stop-the-world event. Setting gcstoptheworld=2
 	also disables concurrent sweeping after the garbage collection finishes.
 
+	gcnoassist: setting gcnoassist=1 disables garbage collection assist, minimizing
+	garbage collection overhead for user goroutines at the expense of a higher risk
+	of out-of-memory failures with high allocation rates.
+
 	gctrace: setting gctrace=1 causes the garbage collector to emit a single line to standard
 	error at each collection, summarizing the amount of memory collected and the
 	length of the pause. The format of this line is subject to change. Included in

--- a/src/runtime/malloc.go
+++ b/src/runtime/malloc.go
@@ -1663,20 +1663,22 @@ func postMallocgcDebug(x unsafe.Pointer, elemsize uintptr, typ *_type) {
 //
 // Returns the G for which the assist credit was accounted.
 func deductAssistCredit(size uintptr) {
-	// Charge the current user G for this allocation.
-	assistG := getg()
-	if assistG.m.curg != nil {
-		assistG = assistG.m.curg
-	}
-	// Charge the allocation against the G. We'll account
-	// for internal fragmentation at the end of mallocgc.
-	assistG.gcAssistBytes -= int64(size)
+	if debug.gcnoassist == 0 {
+		// Charge the current user G for this allocation.
+		assistG := getg()
+		if assistG.m.curg != nil {
+			assistG = assistG.m.curg
+		}
+		// Charge the allocation against the G. We'll account
+		// for internal fragmentation at the end of mallocgc.
+		assistG.gcAssistBytes -= int64(size)
 
-	if assistG.gcAssistBytes < 0 {
-		// This G is in debt. Assist the GC to correct
-		// this before allocating. This must happen
-		// before disabling preemption.
-		gcAssistAlloc(assistG)
+		if assistG.gcAssistBytes < 0 {
+			// This G is in debt. Assist the GC to correct
+			// this before allocating. This must happen
+			// before disabling preemption.
+			gcAssistAlloc(assistG)
+		}
 	}
 }
 

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -1155,6 +1155,11 @@ func casfrom_Gscanstatus(gp *g, oldval, newval uint32) {
 		dumpgstatus(gp)
 		throw("casfrom_Gscanstatus: gp->status is not in scan state")
 	}
+	// We're transitioning into the running state, record the timestamp for
+	// subsequent use.
+	if newval == _Grunning {
+		gp.lastsched = nanotime()
+	}
 	releaseLockRankAndM(lockRankGscan)
 }
 
@@ -1170,6 +1175,11 @@ func castogscanstatus(gp *g, oldval, newval uint32) bool {
 			r := gp.atomicstatus.CompareAndSwap(oldval, newval)
 			if r {
 				acquireLockRankAndM(lockRankGscan)
+				// We're transitioning out of running, record how long we were in the
+				// state.
+				if oldval == _Grunning {
+					gp.runningnanos += nanotime() - gp.lastsched
+				}
 			}
 			return r
 
@@ -1235,7 +1245,18 @@ func casgstatus(gp *g, oldval, newval uint32) {
 		})
 	}
 
+	now := nanotime()
+	if newval == _Grunning {
+		// We're transitioning into the running state, record the timestamp for
+		// subsequent use.
+		gp.lastsched = now
+	}
+
 	if oldval == _Grunning {
+		// We're transitioning out of running, record how long we were in the
+		// state.
+		gp.runningnanos += now - gp.lastsched
+
 		// Track every gTrackingPeriod time a goroutine transitions out of running.
 		if casgstatusAlwaysTrack || gp.trackingSeq%gTrackingPeriod == 0 {
 			gp.tracking = true
@@ -1256,7 +1277,6 @@ func casgstatus(gp *g, oldval, newval uint32) {
 		// We transitioned out of runnable, so measure how much
 		// time we spent in this state and add it to
 		// runnableTime.
-		now := nanotime()
 		gp.runnableTime += now - gp.trackingStamp
 		gp.trackingStamp = 0
 	case _Gwaiting:
@@ -1269,7 +1289,6 @@ func casgstatus(gp *g, oldval, newval uint32) {
 		// a more representative estimate of the absolute value.
 		// gTrackingPeriod also represents an accurate sampling period
 		// because we can only enter this state from _Grunning.
-		now := nanotime()
 		sched.totalMutexWaitTime.Add((now - gp.trackingStamp) * gTrackingPeriod)
 		gp.trackingStamp = 0
 	}
@@ -1280,12 +1299,10 @@ func casgstatus(gp *g, oldval, newval uint32) {
 			break
 		}
 		// Blocking on a lock. Write down the timestamp.
-		now := nanotime()
 		gp.trackingStamp = now
 	case _Grunnable:
 		// We just transitioned into runnable, so record what
 		// time that happened.
-		now := nanotime()
 		gp.trackingStamp = now
 	case _Grunning:
 		// We're transitioning into running, so turn off
@@ -1334,6 +1351,10 @@ func casGToPreemptScan(gp *g, old, new uint32) {
 	// ordering between the gscan and synctest locks. syncGroup doesn't
 	// distinguish between _Grunning and _Gpreempted anyway, so not
 	// notifying it is fine.
+
+	// We're transitioning out of running, record how long we were in the
+	// state.
+	gp.runningnanos += nanotime() - gp.lastsched
 }
 
 // casGFromPreempted attempts to transition gp from _Gpreempted to
@@ -4084,6 +4105,14 @@ func dropg() {
 	setGNoWB(&gp.m.curg, nil)
 }
 
+// Grunningnanos returns the wall time spent by current g in the running state.
+// A goroutine may be running on an OS thread that's descheduled by the OS
+// scheduler, this time still counts towards the metric.
+func Grunningnanos() int64 {
+	gp := getg()
+	return gp.runningnanos + nanotime() - gp.lastsched
+}
+
 func parkunlock_c(gp *g, lock unsafe.Pointer) bool {
 	unlock((*mutex)(lock))
 	return true
@@ -4336,6 +4365,8 @@ func gdestroy(gp *g) {
 	gp.labels = nil
 	gp.timer = nil
 	gp.syncGroup = nil
+	gp.lastsched = 0
+	gp.runningnanos = 0
 
 	if gcBlackenEnabled != 0 && gp.gcAssistBytes > 0 {
 		// Flush assist credit to the global pool. This gives

--- a/src/runtime/runtime1.go
+++ b/src/runtime/runtime1.go
@@ -316,6 +316,7 @@ var debug struct {
 	gcpacertrace             int32
 	gcshrinkstackoff         int32
 	gcstoptheworld           int32
+	gcnoassist               int32
 	gctrace                  int32
 	invalidptr               int32
 	madvdontneed             int32 // for Linux; issue 28466
@@ -376,6 +377,7 @@ var dbgvars = []*dbgVar{
 	{name: "gcpacertrace", value: &debug.gcpacertrace},
 	{name: "gcshrinkstackoff", value: &debug.gcshrinkstackoff},
 	{name: "gcstoptheworld", value: &debug.gcstoptheworld},
+	{name: "gcnoassist", value: &debug.gcnoassist},
 	{name: "gctrace", value: &debug.gctrace},
 	{name: "harddecommit", value: &debug.harddecommit},
 	{name: "inittrace", value: &debug.inittrace},

--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -489,6 +489,9 @@ type g struct {
 	// current in-progress goroutine profile
 	goroutineProfiled goroutineProfileStateHolder
 
+	lastsched    int64 // timestamp when the G last started running
+	runningnanos int64 // wall time spent in the running state
+
 	coroarg   *coro // argument during coroutine transfers
 	syncGroup *synctestGroup
 

--- a/src/runtime/sizeof_test.go
+++ b/src/runtime/sizeof_test.go
@@ -20,7 +20,7 @@ func TestSizeof(t *testing.T) {
 		_32bit uintptr // size on 32bit platforms
 		_64bit uintptr // size on 64bit platforms
 	}{
-		{runtime.G{}, 280, 440},   // g, but exported for testing
+		{runtime.G{}, 296, 456},   // g, but exported for testing
 		{runtime.Sudog{}, 56, 88}, // sudog, but exported for testing
 	}
 


### PR DESCRIPTION
Add a routine that returns the wall time spent by current goroutine in the running state.

This is a port of https://github.com/cockroachdb/go/commit/412599a31f4923160033b6afc504714114efec28

It required some manual merging.