### PR TITLE
cockroach-go1.25rc2: runtime: add CurrentP

### DIFF
--- a/src/runtime/cockroach.go
+++ b/src/runtime/cockroach.go
@@ -1,0 +1,12 @@
+package runtime
+
+// CurrentP returns the index of the current P, between 0 and the current
+// GOMAXPROCS.
+//
+// This can only be used as a best-effort facility; there is no guarantee that
+// the goroutine still runs on the same P when this function returns.
+func CurrentP() int {
+	// Note: preemption is not possible in-between these loads (there are no
+	// preemption-safe points).
+	return int(getg().m.p.ptr().id)
+}


### PR DESCRIPTION
Add a simple function that returns the index of the P the goroutine is running on. This will be used for efficient sharding of data structures.

Port of #6