### PR TITLE
runtime: add goroutine labels to traceback/debug=2 headers

### DIFF
--- a/src/runtime/traceback.go
+++ b/src/runtime/traceback.go
@@ -1264,7 +1264,21 @@ func goroutineheader(gp *g) {
 	if bubble := gp.bubble; bubble != nil {
 		print(", synctest bubble ", bubble.id)
 	}
+	if gp.labels != nil {
+		printLabelMap(gp.labels)
+	}
 	print("]:\n")
+}
+
+// printLabelMap prints a pprof.labelMap while avoiding a dependency on pprof.
+func printLabelMap(p unsafe.Pointer) {
+	if p == nil {
+		return
+	}
+	// This must match the layout of pprof/label.go's labelMap and labelSet.
+	for _, lbl := range *(*([]struct{ k, v string }))(p) {
+		print(`, "`, lbl.k, `":"`, lbl.v, `"`)
+	}
 }
 
 func tracebackothers(me *g) {

--- a/src/runtime/traceback_test.go
+++ b/src/runtime/traceback_test.go
@@ -6,12 +6,14 @@ package runtime_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"internal/abi"
 	"internal/testenv"
 	"regexp"
 	"runtime"
 	"runtime/debug"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	"sync"
@@ -866,4 +868,16 @@ func TestTracebackGeneric(t *testing.T) {
 			t.Errorf("traceback contains shape name: got\n%s", got)
 		}
 	}
+}
+
+func TestTracebackContainsLabels(t *testing.T) {
+	pprof.Do(context.Background(), pprof.Labels("foolabel", "barvalue"), func(_ context.Context) {
+		buf := make([]byte, 1<<10)
+		n := runtime.Stack(buf, false)
+		header := strings.Split(string(buf[:n]), "\n")[0]
+		t.Log(header)
+		if !strings.Contains(header, `"foolabel":"barvalue"`) {
+			t.Errorf("stack does not contain label:\n%s", string(buf[:n]))
+		}
+	})
 }


### PR DESCRIPTION
This is a small, self-contained patch to include goroutine labels in the debug=2/ traceback/runtime.Stack format goroutine dumps, as labels are extremely useful in correlating a given goroutine with some user-facing operation or behavior.

We cannot directly import or use the pprof.labelMap type in the traceback code, but we can cast to an equivalent type and iterate over it to print the labels.

This adds them to the header, eg. goroutine 123 [select, 7m, "foobar:1", "barbaz:abc"]:
