### PR TITLE
runtime/pprof: add debug=3 goroutine profile with goid and labels

### DIFF
--- a/src/internal/profilerecord/profilerecord.go
+++ b/src/internal/profilerecord/profilerecord.go
@@ -10,6 +10,22 @@ package profilerecord
 
 type StackRecord struct {
 	Stack []uintptr
+
+	// Extra fields for goroutine profiles, unused in threadcreate.
+	// Ideally labels would be here too instead of a separate []labelMap being
+	// passed around along-side the []StackRecord, but that that changes function
+	// signatures in more places which isn't something we want to rebase on our
+	// fork, so that cleanup is deferred to if/when this upstreams. An upstream
+	// version would ideally also rename this to GoroutineRecord and maybe keep a
+	// minimal StackRecord or ThreadCreateRecord type where this extra info isn't
+	// used.
+	ID         uint64
+	State      uint32
+	WaitReason uint8
+	CreatorID  uint64
+	CreationPC uintptr
+	WaitSince  int64 // approx time when the g became blocked, in nanoseconds
+
 }
 
 type MemProfileRecord struct {

--- a/src/net/http/pprof/pprof.go
+++ b/src/net/http/pprof/pprof.go
@@ -263,7 +263,7 @@ func (name handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		runtime.GC()
 	}
 	debug, _ := strconv.Atoi(r.FormValue("debug"))
-	if debug != 0 {
+	if debug != 0 && !(name == "goroutine" && debug == 3) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	} else {
 		w.Header().Set("Content-Type", "application/octet-stream")

--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -1345,6 +1345,13 @@ func goroutineProfileWithLabelsConcurrent(p []profilerecord.StackRecord, labels 
 	systemstack(func() {
 		saveg(pc, sp, ourg, &p[0], pcbuf)
 	})
+
+	p[0].ID = ourg.goid
+	p[0].CreatorID = ourg.parentGoid
+	p[0].CreationPC = ourg.gopc
+	p[0].State = readgstatus(ourg) &^ _Gscan
+	p[0].WaitReason = uint8(ourg.waitreason)
+	p[0].WaitSince = ourg.waitsince
 	if labels != nil {
 		labels[0] = ourg.labels
 	}
@@ -1502,6 +1509,13 @@ func doRecordGoroutineProfile(gp1 *g, pcbuf []uintptr) {
 	// preventing it from being truly _Grunnable. So we'll use the system stack
 	// to avoid schedule delays.
 	systemstack(func() { saveg(^uintptr(0), ^uintptr(0), gp1, &goroutineProfile.records[offset], pcbuf) })
+
+	goroutineProfile.records[offset].ID = gp1.goid
+	goroutineProfile.records[offset].CreatorID = gp1.parentGoid
+	goroutineProfile.records[offset].CreationPC = gp1.gopc
+	goroutineProfile.records[offset].State = readgstatus(gp1) &^ _Gscan
+	goroutineProfile.records[offset].WaitReason = uint8(gp1.waitreason)
+	goroutineProfile.records[offset].WaitSince = gp1.waitsince
 
 	if goroutineProfile.labels != nil {
 		goroutineProfile.labels[offset] = gp1.labels

--- a/src/runtime/pprof/pprof.go
+++ b/src/runtime/pprof/pprof.go
@@ -362,7 +362,9 @@ func (p *Profile) Remove(value any) {
 // The predefined profiles may assign meaning to other debug values;
 // for example, when printing the "goroutine" profile, debug=2 means to
 // print the goroutine stacks in the same form that a Go program uses
-// when dying due to an unrecovered panic.
+// when dying due to an unrecovered panic, and debug=3 means to output a
+// binary protobuf profile identical to debug=0, but with per-goroutine
+// details such as ID and status included as sample labels.
 func (p *Profile) WriteTo(w io.Writer, debug int) error {
 	if p.name == "" {
 		panic("pprof: use of zero Profile")
@@ -451,7 +453,55 @@ func printCountCycleProfile(w io.Writer, countName, cycleName string, records []
 
 // printCountProfile prints a countProfile at the specified debug level.
 // The profile will be in compressed proto format unless debug is nonzero.
+// Non-zero debug values have the following behaviors:
+//   - debug=1: text format, aggregated by unique stack, state and labels.
+//   - debug=2: handled elsewhere; the output of runtime.Stack().
+//   - debug=3: binary proto format-identical to debug=0 with per-goroutine labels.
 func printCountProfile(w io.Writer, debug int, name string, p countProfile) error {
+	// Debug >1 is non-aggregated, so branch immediately to avoid computing the
+	// aggregated map if we do not need it. This does duplicate a little of the
+	// logic for actually constructing and outputting the proto profile but only
+	// the helper calls so it is minimal and avoids a more complex structuring of
+	// one output path that handles both the aggregated and non-aggregated cases.
+	if debug == 3 {
+		// Output profile in protobuf form.
+		b := newProfileBuilder(w)
+		b.pbValueType(tagProfile_PeriodType, name, "count")
+		b.pb.int64Opt(tagProfile_Period, 1)
+		b.pbValueType(tagProfile_SampleType, name, "count")
+
+		values := []int64{1}
+		var locs []uint64
+		for i := 0; i < p.Len(); i++ {
+			locs = b.appendLocsForStack(locs[:0], p.Stack(i))
+			var g profilerecord.StackRecord
+			if goroutines, ok := p.(*runtimeProfile); ok {
+				g = goroutines.stk[i]
+			}
+			extra := func() {
+				// If the stackrecord has goroutine details (starting with ID), use them
+				// to synthesize labels.
+				if g.ID != 0 {
+					b.pbLabelNum(tagSample_Label, "go::goroutine", int64(g.ID))
+					if g.ID != 1 {
+						b.pbLabelNum(tagSample_Label, "go::goroutine_created_by", int64(g.CreatorID))
+					}
+					b.pbLabel(tagSample_Label, "go::goroutine_state", pprof_gStatusString(g.State, g.WaitReason), 0)
+					if mins := pprof_gWaitFor(g.State, g.WaitSince); mins > 0 {
+						b.pbLabelNum(tagSample_Label, "go::goroutine_wait_minutes", int64(mins))
+					}
+				}
+				if lbl := p.Label(i); lbl != nil {
+					for _, lbl := range lbl.list {
+						b.pbLabel(tagSample_Label, lbl.key, lbl.value, 0)
+					}
+				}
+			}
+			b.pbSample(values, locs, extra)
+		}
+		return b.build()
+	}
+
 	// Build count of each stack.
 	var buf strings.Builder
 	key := func(stk []uintptr, lbls *labelMap) string {
@@ -741,7 +791,7 @@ func countGoroutine() int {
 
 // writeGoroutine writes the current runtime GoroutineProfile to w.
 func writeGoroutine(w io.Writer, debug int) error {
-	if debug >= 2 {
+	if debug == 2 {
 		return writeGoroutineStacks(w)
 	}
 	return writeRuntimeProfile(w, debug, "goroutine", pprof_goroutineProfileWithLabels)
@@ -989,3 +1039,9 @@ func pprof_fpunwindExpand(dst, src []uintptr) int
 
 //go:linkname pprof_makeProfStack runtime.pprof_makeProfStack
 func pprof_makeProfStack() []uintptr
+
+//go:linkname pprof_gStatusString runtime.pprof_gStatusString
+func pprof_gStatusString(state uint32, reason uint8) string
+
+//go:linkname pprof_gWaitFor runtime.pprof_gWaitFor
+func pprof_gWaitFor(gpstatus uint32, waitsince int64) int64

--- a/src/runtime/pprof/pprof_test.go
+++ b/src/runtime/pprof/pprof_test.go
@@ -1934,6 +1934,195 @@ func BenchmarkGoroutine(b *testing.B) {
 	}
 }
 
+func TestGoroutineProfileDebug3Creators(t *testing.T) {
+	// Create synthetic goroutines using the helper
+	cleanup := createSyntheticGoroutines(10, 2)
+	defer cleanup()
+
+	p := Lookup("goroutine")
+
+	// Establish a created-by mapping by parsing a debug=2 profile.
+	createdBy := make(map[string]string)
+	var buf bytes.Buffer
+	err := p.WriteTo(&buf, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, goroutine := range strings.Split(buf.String(), "\n\n") {
+		parts := strings.SplitN(goroutine, " ", 3)
+		for _, l := range strings.Split(parts[2], "\n") {
+			if c := strings.Split(l, "in goroutine "); len(c) > 1 {
+				createdBy[parts[1]] = c[1]
+			}
+		}
+	}
+
+	// Verify the debug=3 format of said profile has matching ID and creator labels.
+	buf.Reset()
+	err = p.WriteTo(&buf, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := profile.Parse(&buf)
+	if err != nil {
+		t.Fatalf("failed to parse profile: %v", err)
+	}
+	if e, g := len(createdBy), len(parsed.Sample); e > g {
+		t.Fatalf("expected %d goroutines, got %d", e, g)
+	}
+	for _, s := range parsed.Sample {
+		id := strconv.Itoa(int(s.NumLabel["go::goroutine"][0]))
+		got := s.NumLabel["go::goroutine_created_by"]
+		if createdBy[id] == "" {
+			if len(got) != 0 {
+				t.Fatalf("goroutine %s: got created_by %q, want none", id, got)
+			}
+		} else {
+			if e := createdBy[id]; len(got) != 1 || strconv.Itoa(int(got[0])) != e {
+				t.Fatalf("goroutine %s: got created_by %q, want %q", id, got, e)
+			}
+		}
+	}
+}
+
+// BenchmarkGoroutineProfileLatencyImpact measures the latency impact on *other*
+// running goroutines during goroutine profile collection, when variable numbers
+// of other goroutines are profiled. This focus on the observed latency of in
+// other goroutines is what differentiates this benchmark from other benchmarks
+// of goroutine profiling, such as BenchmarkGoroutine, that measure the
+// the performance of profiling itself rather than its impact on the performance
+// of concurrently executing goroutines.
+func BenchmarkGoroutineProfileLatencyImpact(b *testing.B) {
+	for _, numGoroutines := range []int{100, 1000, 10000} {
+		for _, withDepth := range []int{3, 10, 50} {
+			b.Run(fmt.Sprintf("goroutines=%dx%d", numGoroutines, withDepth), func(b *testing.B) {
+				// Setup synthetic blocked goroutines using helper
+				cleanup := createSyntheticGoroutines(numGoroutines, withDepth)
+				defer cleanup()
+				for _, debug := range []int{-1, 1, 2, 3} {
+					name := fmt.Sprintf("debug=%d", debug)
+					if debug < 0 {
+						name = "debug=none"
+					}
+					b.Run(name, func(b *testing.B) {
+						// Launch latency probe goroutines.
+						const numProbes = 3
+						probeStop := make(chan struct{})
+						var probeWg, probesReady sync.WaitGroup
+						probes := make([]time.Duration, numProbes)
+						for prober := 0; prober < numProbes; prober++ {
+							probeWg.Add(1)
+							probesReady.Add(1)
+							go func(idx int) {
+								defer probeWg.Done()
+								probesReady.Done()
+								for {
+									select {
+									case <-probeStop:
+										return
+									default:
+										last := time.Now()
+										for i := 0; i < 20; i++ {
+											latency := time.Since(last)
+											last = time.Now()
+											if probes[idx] < latency {
+												probes[idx] = latency
+											}
+										}
+									}
+								}
+							}(prober)
+						}
+						probesReady.Wait()
+						b.ResetTimer()
+						for i := 0; i < b.N; i++ {
+							if debug >= 0 {
+								time.Sleep(3 * time.Millisecond)
+								var buf bytes.Buffer
+								err := Lookup("goroutine").WriteTo(&buf, debug)
+								if err != nil {
+									b.Fatalf("Profile failed: %v", err)
+								}
+								time.Sleep(3 * time.Millisecond)
+							} else {
+								// Just observe the probes without a profile interrupting them.
+								time.Sleep(6 * time.Millisecond)
+							}
+						}
+						b.StopTimer()
+						close(probeStop)
+						probeWg.Wait()
+
+						var probeMax time.Duration
+						for _, probe := range probes {
+							if probe > probeMax {
+								probeMax = probe
+							}
+						}
+						b.ReportMetric(float64(probeMax), "max_latency_ns")
+					})
+				}
+			})
+		}
+	}
+}
+
+// createSyntheticGoroutines creates a requested number of goroutines to provide
+// testdata against which various goroutine profiling mechanisms such as
+// pprof.Lookup("goroutine").WriteTo(debug=1/2) can be tested or benchmarked.
+// After the requested goroutines are started it returns a cleanup function to
+// stop them. The created goroutines vary their stacks across several sythnetic
+// functions, with a minimum stack depth controlled by minDepth.
+func createSyntheticGoroutines(numGoroutines, minDepth int) func() {
+	var syntheticFn0, syntheticFn1, syntheticFn2 func(<-chan struct{}, int)
+
+	syntheticFn0 = func(ch <-chan struct{}, d int) {
+		if d > 0 {
+			syntheticFn1(ch, d-1)
+		}
+		<-ch
+	}
+	syntheticFn1 = func(ch <-chan struct{}, d int) {
+		if d > 0 {
+			syntheticFn2(ch, d-1)
+		}
+		<-ch
+	}
+	syntheticFn2 = func(ch <-chan struct{}, d int) {
+		if d > 0 {
+			syntheticFn0(ch, d-1)
+		}
+		<-ch
+	}
+
+	var wg, setup sync.WaitGroup
+	setup.Add(numGoroutines)
+	blockCh := make(chan struct{})
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			setup.Done()
+			depth := minDepth + (id % 7)
+			switch id % 4 {
+			case 0:
+				syntheticFn0(blockCh, depth)
+			case 1:
+				syntheticFn1(blockCh, depth)
+			case 2:
+				syntheticFn2(blockCh, depth)
+			}
+		}(i)
+	}
+	setup.Wait()
+
+	return func() {
+		close(blockCh)
+		wg.Wait()
+	}
+}
+
 var emptyCallStackTestRun int64
 
 // Issue 18836.

--- a/src/runtime/pprof/proto.go
+++ b/src/runtime/pprof/proto.go
@@ -177,6 +177,14 @@ func (b *profileBuilder) pbLabel(tag int, key, str string, num int64) {
 	b.pb.endMessage(tag, start)
 }
 
+// pbLabel encodes a Label message to b.pb, with only a num component.
+func (b *profileBuilder) pbLabelNum(tag int, key string, num int64) {
+	start := b.pb.startMessage()
+	b.pb.int64Opt(tagLabel_Key, b.stringIndex(key))
+	b.pb.int64Opt(tagLabel_Num, num)
+	b.pb.endMessage(tag, start)
+}
+
 // pbLine encodes a Line message to b.pb.
 func (b *profileBuilder) pbLine(tag int, funcID uint64, line int64) {
 	start := b.pb.startMessage()

--- a/src/runtime/traceback.go
+++ b/src/runtime/traceback.go
@@ -1218,23 +1218,10 @@ func goroutineheader(gp *g) {
 	gpstatus &^= _Gscan // drop the scan bit
 
 	// Basic string status
-	var status string
-	if 0 <= gpstatus && gpstatus < uint32(len(gStatusStrings)) {
-		status = gStatusStrings[gpstatus]
-	} else {
-		status = "???"
-	}
-
-	// Override.
-	if gpstatus == _Gwaiting && gp.waitreason != waitReasonZero {
-		status = gp.waitreason.String()
-	}
-
+	status := gStatusString(gpstatus, gp.waitreason)
 	// approx time the G is blocked, in minutes
-	var waitfor int64
-	if (gpstatus == _Gwaiting || gpstatus == _Gsyscall) && gp.waitsince != 0 {
-		waitfor = (nanotime() - gp.waitsince) / 60e9
-	}
+	waitfor := gWaitFor(gpstatus, gp.waitsince)
+
 	print("goroutine ", gp.goid)
 	if gp.m != nil && gp.m.throwing >= throwTypeRuntime && gp == gp.m.curg || level >= 2 {
 		print(" gp=", gp)
@@ -1244,6 +1231,7 @@ func goroutineheader(gp *g) {
 			print(" m=nil")
 		}
 	}
+
 	print(" [", status)
 	if isScan {
 		print(" (scan)")
@@ -1279,6 +1267,38 @@ func printLabelMap(p unsafe.Pointer) {
 	for _, lbl := range *(*([]struct{ k, v string }))(p) {
 		print(`, "`, lbl.k, `":"`, lbl.v, `"`)
 	}
+}
+
+// gStatusString returns a string representing the status of a goroutine.
+func gStatusString(gpstatus uint32, reason waitReason) string {
+	var status string
+	if gpstatus < uint32(len(gStatusStrings)) {
+		status = gStatusStrings[gpstatus]
+	} else {
+		status = "???"
+	}
+	if gpstatus == _Gwaiting && reason != waitReasonZero {
+		status = reason.String()
+	}
+	return status
+}
+
+// gWaitFor returns the number of minutes that the goroutine has been waiting.
+func gWaitFor(gpstatus uint32, waitsince int64) int64 {
+	if (gpstatus == _Gwaiting || gpstatus == _Gsyscall) && waitsince != 0 {
+		return (nanotime() - waitsince) / 60e9
+	}
+	return 0
+}
+
+//go:linkname pprof_gWaitFor
+func pprof_gWaitFor(gpstatus uint32, waitsince int64) int64 {
+	return gWaitFor(gpstatus, waitsince)
+}
+
+//go:linkname pprof_gStatusString
+func pprof_gStatusString(gpstatus uint32, reason waitReason) string {
+	return gStatusString(gpstatus, reason)
 }
 
 func tracebackothers(me *g) {


### PR DESCRIPTION
This adds a new goroutine profile debug mode, debug=3.

This mode emits in the same binary proto output format as debug=0, with the only difference being that it does not aggregate matching stack/label combinations into a single count, and instead emits a sample per goroutine with additional synthesized labels to communicate some of the details of each goroutine, specifically:
  - go::goroutine: the goroutine's ID
  - go::goroutine_created_by: ID of the goroutine's creator (if any)
  - go::goroutine_state: current state of the goroutine (e.g. runnable)
  - go::goroutine_wait_minutes: approximate minutes goroutine has spent waiting (if applicable)

Previously the debug=2 mode was the only way to get this kind of per-goroutine information, that is sometimes vital to understanding the state of a process. However debug=2 has two major drawbacks:
  1) its collection incurs a lengthy and disruptive stop-the-world pause and
  2) it does not include user-set labels along side per-goroutine details in the same profile.

This new debug=3 mode uses the same concurrent collection mechanism used to produce debug=0 and debug=1 profiles, meaning it has the same minimial stop-the-world penalty. At the same time, it includes the per-goroutine details like status and wait time that make debug=2 so useful, providing a "best-of-both-worlds" option.

A new mode is introduced, rather than changing the implementation of the debug=2 format in-place, as it is not clear that debug=2 can utilize a concurrent collection mechanism while maintaining the correctness of its existing output, which includes argument values in its printed stacks.

The difference in STW latency observed by running goroutines during profile collection is demonstrated by an included benchmark which spawns a number of goroutines to be profiled and then measures the latency of a short timer while collecting goroutine profiles.

```
BenchmarkGoroutineProfileLatencyImpact

                       │        debug=2  │                   debug=3             │
                       │ max_latency_ns  │ max_latency_ns  vs base               │
goroutines=100x3-14         422.2k ± 13%   190.3k ±   38%  -54.93% (p=0.002 n=6)
goroutines=100x10-14        619.7k ± 10%   171.1k ±   43%  -72.38% (p=0.002 n=6)
goroutines=100x50-14       1423.6k ±  7%   174.3k ±   44%  -87.76% (p=0.002 n=6)
goroutines=1000x3-14       2424.8k ±  8%   298.6k ±  106%  -87.68% (p=0.002 n=6)
goroutines=1000x10-14      7378.4k ±  2%   268.2k ±  146%  -96.36% (p=0.002 n=6)
goroutines=1000x50-14     23372.5k ± 10%   330.1k ±  173%  -98.59% (p=0.002 n=6)
goroutines=10000x3-14      42.802M ± 47%   1.991M ±  105%  -95.35% (p=0.002 n=6)
goroutines=10000x10-14    36668.2k ± 95%   743.1k ±   72%  -97.97% (p=0.002 n=6)
goroutines=10000x50-14   120639.1k ±  2%   188.2k ± 2582%  -99.84% (p=0.002 n=6)
geomean                     6.760M         326.2k          -95.18%
```

The per-goroutine details are included in the profile as labels, along side any user-set labels. While the pprof format allows for multi-valued labels, so a collision with a user-set label would preserve both values, it also discourages them, thus the 'go::' namespace prefix is used to minimize collisions with user-set labels. The form 'go::' follows the convention established in the pprof format, which reserves 'pprof::'.
