### PR TITLE
add `Running` and `LastSched` to debug=3

### DIFF
--- a/src/internal/profilerecord/profilerecord.go
+++ b/src/internal/profilerecord/profilerecord.go
@@ -25,7 +25,8 @@ type StackRecord struct {
 	CreatorID  uint64
 	CreationPC uintptr
 	WaitSince  int64 // approx time when the g became blocked, in nanoseconds
-
+	LastSched  int64 // time of the last transition to the running state, in nanoseconds
+	Running    int64 // approx time spent in the running state, in nanoseconds
 }
 
 type MemProfileRecord struct {

--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -1352,6 +1352,8 @@ func goroutineProfileWithLabelsConcurrent(p []profilerecord.StackRecord, labels 
 	p[0].State = readgstatus(ourg) &^ _Gscan
 	p[0].WaitReason = uint8(ourg.waitreason)
 	p[0].WaitSince = ourg.waitsince
+	p[0].LastSched = ourg.lastsched
+	p[0].Running = ourg.runningnanos
 	if labels != nil {
 		labels[0] = ourg.labels
 	}
@@ -1516,6 +1518,8 @@ func doRecordGoroutineProfile(gp1 *g, pcbuf []uintptr) {
 	goroutineProfile.records[offset].State = readgstatus(gp1) &^ _Gscan
 	goroutineProfile.records[offset].WaitReason = uint8(gp1.waitreason)
 	goroutineProfile.records[offset].WaitSince = gp1.waitsince
+	goroutineProfile.records[offset].LastSched = gp1.lastsched
+	goroutineProfile.records[offset].Running = gp1.runningnanos
 
 	if goroutineProfile.labels != nil {
 		goroutineProfile.labels[offset] = gp1.labels

--- a/src/runtime/pprof/pprof.go
+++ b/src/runtime/pprof/pprof.go
@@ -487,8 +487,14 @@ func printCountProfile(w io.Writer, debug int, name string, p countProfile) erro
 						b.pbLabelNum(tagSample_Label, "go::goroutine_created_by", int64(g.CreatorID))
 					}
 					b.pbLabel(tagSample_Label, "go::goroutine_state", pprof_gStatusString(g.State, g.WaitReason), 0)
-					if mins := pprof_gWaitFor(g.State, g.WaitSince); mins > 0 {
-						b.pbLabelNum(tagSample_Label, "go::goroutine_wait_minutes", int64(mins))
+					if nanos := pprof_gWaitFor(g.State, g.WaitSince); nanos > 0 {
+						b.pbLabelNum(tagSample_Label, "go::goroutine_wait_nanos", nanos)
+					}
+					if g.LastSched > 0 {
+						b.pbLabelNum(tagSample_Label, "go::goroutine_last_sched", pprof_elapsedNanos(g.LastSched))
+					}
+					if g.Running > 0 {
+						b.pbLabelNum(tagSample_Label, "go::goroutine_running_nanos", g.Running)
 					}
 				}
 				if lbl := p.Label(i); lbl != nil {
@@ -1042,6 +1048,9 @@ func pprof_makeProfStack() []uintptr
 
 //go:linkname pprof_gStatusString runtime.pprof_gStatusString
 func pprof_gStatusString(state uint32, reason uint8) string
+
+//go:linkname pprof_elapsedNanos runtime.pprof_elapsedNanos
+func pprof_elapsedNanos(t int64) int64
 
 //go:linkname pprof_gWaitFor runtime.pprof_gWaitFor
 func pprof_gWaitFor(gpstatus uint32, waitsince int64) int64

--- a/src/runtime/traceback.go
+++ b/src/runtime/traceback.go
@@ -1220,7 +1220,7 @@ func goroutineheader(gp *g) {
 	// Basic string status
 	status := gStatusString(gpstatus, gp.waitreason)
 	// approx time the G is blocked, in minutes
-	waitfor := gWaitFor(gpstatus, gp.waitsince)
+	waitfor := gWaitFor(gpstatus, gp.waitsince) / 60e9
 
 	print("goroutine ", gp.goid)
 	if gp.m != nil && gp.m.throwing >= throwTypeRuntime && gp == gp.m.curg || level >= 2 {
@@ -1283,10 +1283,10 @@ func gStatusString(gpstatus uint32, reason waitReason) string {
 	return status
 }
 
-// gWaitFor returns the number of minutes that the goroutine has been waiting.
+// gWaitFor returns the number of nanoseconds that the goroutine has been waiting.
 func gWaitFor(gpstatus uint32, waitsince int64) int64 {
 	if (gpstatus == _Gwaiting || gpstatus == _Gsyscall) && waitsince != 0 {
-		return (nanotime() - waitsince) / 60e9
+		return pprof_elapsedNanos(waitsince)
 	}
 	return 0
 }
@@ -1299,6 +1299,11 @@ func pprof_gWaitFor(gpstatus uint32, waitsince int64) int64 {
 //go:linkname pprof_gStatusString
 func pprof_gStatusString(gpstatus uint32, reason waitReason) string {
 	return gStatusString(gpstatus, reason)
+}
+
+//go:linkname pprof_elapsedNanos
+func pprof_elapsedNanos(t int64) int64 {
+	return nanotime() - t
 }
 
 func tracebackothers(me *g) {


### PR DESCRIPTION
In [1], `StackRecord` was extended with
extra fields for goroutine profiles
in conjunction with debug=3.

To facilitate troubleshooting
scheduling delays, it's instructive
to include both `Running` and `LastSched`.
The latter is the time since the goroutine's
last transition to the running state; the former
is an approximate time spent in the running state. Both fields are in `g` and thus require no computation.

Since the above are in nanos, we also modify `WaitSince` to be in nanos. Previous caller, i.e., `goroutineheader` is updated to keep the minutes resolution.

[1] https://github.com/cockroachdb/go/pull/12