### PR TITLE
runtime: make gcnoassist dynamically toggleable via SetGCAssistEnabled

### DIFF
--- a/src/runtime/debug.go
+++ b/src/runtime/debug.go
@@ -291,3 +291,28 @@ func NumRunnableGoroutines() (numRunnable int, numProcs int) {
 	releasem(mp)
 	return numRunnable, numProcs
 }
+
+// SetGCAssistEnabled controls whether GC assist is enabled.
+// When GC assist is enabled (the default), goroutines that allocate
+// are charged for their allocations and may be required to assist the
+// garbage collector with marking work. Disabling GC assist minimizes
+// garbage collection overhead for user goroutines at the expense of
+// a higher risk of out-of-memory conditions under high allocation rates.
+//
+// The initial value is determined by the GODEBUG gcnoassist setting.
+//
+// SetGCAssistEnabled returns the previous setting.
+func SetGCAssistEnabled(enabled bool) bool {
+	var v int32
+	if !enabled {
+		v = 1
+	}
+	old := debug.gcnoassist.Swap(v)
+	return old == 0
+}
+
+// GCAssistEnabled reports whether GC assist is currently enabled.
+// See [SetGCAssistEnabled] for details.
+func GCAssistEnabled() bool {
+	return debug.gcnoassist.Load() == 0
+}

--- a/src/runtime/gc_test.go
+++ b/src/runtime/gc_test.go
@@ -215,6 +215,22 @@ func TestGcZombieReporting(t *testing.T) {
 	}
 }
 
+func TestGCNoAssist(t *testing.T) {
+	got := runTestProg(t, "testprog", "GCNoAssist")
+	want := "OK\n"
+	if got != want {
+		t.Fatalf("expected %q, but got %q", want, got)
+	}
+}
+
+func TestGCNoAssistGODEBUG(t *testing.T) {
+	got := runTestProg(t, "testprog", "GCNoAssistGODEBUG", "GODEBUG=gcnoassist=1")
+	want := "OK\n"
+	if got != want {
+		t.Fatalf("expected %q, but got %q", want, got)
+	}
+}
+
 func TestGCTestMoveStackOnNextCall(t *testing.T) {
 	if asan.Enabled {
 		t.Skip("extra allocations with -asan causes this to fail; see #70079")

--- a/src/runtime/malloc.go
+++ b/src/runtime/malloc.go
@@ -1696,7 +1696,7 @@ func postMallocgcDebug(x unsafe.Pointer, elemsize uintptr, typ *_type) {
 //
 // Returns the G for which the assist credit was accounted.
 func deductAssistCredit(size uintptr) {
-	if debug.gcnoassist == 0 {
+	if debug.gcnoassist.Load() == 0 {
 		// Charge the current user G for this allocation.
 		assistG := getg()
 		if assistG.m.curg != nil {

--- a/src/runtime/runtime1.go
+++ b/src/runtime/runtime1.go
@@ -319,7 +319,7 @@ var debug struct {
 	gcpacertrace             int32
 	gcshrinkstackoff         int32
 	gcstoptheworld           int32
-	gcnoassist               int32
+	gcnoassist               atomic.Int32
 	gctrace                  int32
 	invalidptr               int32
 	madvdontneed             int32 // for Linux; issue 28466
@@ -384,7 +384,7 @@ var dbgvars = []*dbgVar{
 	{name: "gcpacertrace", value: &debug.gcpacertrace},
 	{name: "gcshrinkstackoff", value: &debug.gcshrinkstackoff},
 	{name: "gcstoptheworld", value: &debug.gcstoptheworld},
-	{name: "gcnoassist", value: &debug.gcnoassist},
+	{name: "gcnoassist", atomic: &debug.gcnoassist},
 	{name: "gctrace", value: &debug.gctrace},
 	{name: "harddecommit", value: &debug.harddecommit},
 	{name: "inittrace", value: &debug.inittrace},

--- a/src/runtime/testdata/testprog/gc.go
+++ b/src/runtime/testdata/testprog/gc.go
@@ -26,6 +26,8 @@ func init() {
 	register("GCZombie", GCZombie)
 	register("GCMemoryLimit", GCMemoryLimit)
 	register("GCMemoryLimitNoGCPercent", GCMemoryLimitNoGCPercent)
+	register("GCNoAssist", GCNoAssist)
+	register("GCNoAssistGODEBUG", GCNoAssistGODEBUG)
 }
 
 func GCSys() {
@@ -421,3 +423,56 @@ func gcMemoryLimit(gcPercent int) {
 const memLimitUnit = 8000
 
 var memLimitSink []*[memLimitUnit]byte
+
+func GCNoAssist() {
+	// Verify the default state.
+	if !runtime.GCAssistEnabled() {
+		fmt.Println("FAIL: GCAssistEnabled should be true by default")
+		return
+	}
+
+	// Disable and check.
+	prev := runtime.SetGCAssistEnabled(false)
+	if !prev {
+		fmt.Println("FAIL: SetGCAssistEnabled(false) should return true (previous value)")
+		return
+	}
+	if runtime.GCAssistEnabled() {
+		fmt.Println("FAIL: GCAssistEnabled should be false after disabling")
+		return
+	}
+
+	// Allocate while assist is disabled — should not crash.
+	for i := 0; i < 1000; i++ {
+		sink = make([]byte, 1024)
+	}
+	runtime.GC()
+
+	// Re-enable and check.
+	prev = runtime.SetGCAssistEnabled(true)
+	if prev {
+		fmt.Println("FAIL: SetGCAssistEnabled(true) should return false (previous value)")
+		return
+	}
+	if !runtime.GCAssistEnabled() {
+		fmt.Println("FAIL: GCAssistEnabled should be true after re-enabling")
+		return
+	}
+
+	// Allocate while assist is enabled — should not crash.
+	for i := 0; i < 1000; i++ {
+		sink = make([]byte, 1024)
+	}
+	runtime.GC()
+
+	fmt.Println("OK")
+}
+
+func GCNoAssistGODEBUG() {
+	// When GODEBUG=gcnoassist=1, GC assist should be disabled at startup.
+	if runtime.GCAssistEnabled() {
+		fmt.Println("FAIL: GCAssistEnabled should be false with GODEBUG=gcnoassist=1")
+		return
+	}
+	fmt.Println("OK")
+}


### PR DESCRIPTION
## Summary

- Make `debug.gcnoassist` an `atomic.Int32` so it can be toggled at runtime without STW
- Update `dbgvars` registration from `value:` to `atomic:`
- Add `runtime.SetGCAssistEnabled(bool) bool` to dynamically enable/disable GC assist
- Add `runtime.GCAssistEnabled() bool` getter
- The `GODEBUG=gcnoassist=1` env var still controls the initial value at startup

## Test plan

- `go test runtime -run TestGCNoAssist` — exercises dynamic toggle (disable → allocate → re-enable → allocate)
- `go test runtime -run TestGCNoAssistGODEBUG` — verifies `GODEBUG=gcnoassist=1` disables assist at startup
- `go test runtime -run TestGC` — all existing GC tests pass

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-61359