### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - 'cockroach-*'
+  pull_request:
+    branches:
+      - master
+      - 'cockroach-*'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up bootstrap Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.24'
+          cache: false
+
+      - name: Save GOROOT_BOOTSTRAP
+        run: echo "GOROOT_BOOTSTRAP=$(go env GOROOT)" >> "$GITHUB_ENV"
+
+      - name: Build toolchain
+        run: cd src && ./make.bash
+
+      # Run the dist test suite, skipping:
+      #   :race / :race-external — need race detector build (dist test -race)
+      #   testfortran            — needs gfortran
+      #   relnote:check          — needs doc/next/ fragments (not on release branches)
+      - name: Run tests
+        run: |
+          bin/go tool dist test -k \
+            -run '!:(race|race-external)$|testfortran|relnote:check'
+        env:
+          GOROOT: ${{ github.workspace }}

--- a/api/go1.25.txt
+++ b/api/go1.25.txt
@@ -109,3 +109,9 @@ pkg testing/synctest, func Wait() #67434
 pkg unicode, var CategoryAliases map[string]string #70780
 pkg unicode, var Cn *RangeTable #70780
 pkg unicode, var LC *RangeTable #70780
+pkg context, func PropagateCancel(Context, func()) bool #0
+pkg runtime, func CurrentP() int #0
+pkg runtime, func GCAssistEnabled() bool #0
+pkg runtime, func NumRunnableGoroutines() (int, int) #0
+pkg runtime, func SetGCAssistEnabled(bool) bool #0
+pkg runtime, func Yield() int64 #0

--- a/src/runtime/cockroach.go
+++ b/src/runtime/cockroach.go
@@ -1,3 +1,7 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package runtime
 
 // CurrentP returns the index of the current P, between 0 and the current

--- a/src/runtime/pprof/pprof_test.go
+++ b/src/runtime/pprof/pprof_test.go
@@ -404,7 +404,9 @@ func recursionChainBottom(x int, pcs []uintptr) {
 	recursionChainTop(x-1, pcs)
 }
 
-func parseProfile(t *testing.T, valBytes []byte, f func(uintptr, []*profile.Location, map[string][]string)) *profile.Profile {
+func parseProfile(
+	t *testing.T, valBytes []byte, f func(uintptr, []*profile.Location, map[string][]string),
+) *profile.Profile {
 	p, err := profile.Parse(bytes.NewReader(valBytes))
 	if err != nil {
 		t.Fatal(err)
@@ -418,7 +420,9 @@ func parseProfile(t *testing.T, valBytes []byte, f func(uintptr, []*profile.Loca
 
 // testCPUProfile runs f under the CPU profiler, checking for some conditions specified by need,
 // as interpreted by matches, and returns the parsed profile.
-func testCPUProfile(t *testing.T, matches profileMatchFunc, f func(dur time.Duration)) *profile.Profile {
+func testCPUProfile(
+	t *testing.T, matches profileMatchFunc, f func(dur time.Duration),
+) *profile.Profile {
 	switch runtime.GOOS {
 	case "darwin":
 		out, err := testenv.Command(t, "uname", "-a").CombinedOutput()
@@ -502,7 +506,9 @@ func diffCPUTime(t *testing.T, f func()) (user, system time.Duration) {
 }
 
 // stackContains matches if a function named spec appears anywhere in the stack trace.
-func stackContains(spec string, count uintptr, stk []*profile.Location, labels map[string][]string) bool {
+func stackContains(
+	spec string, count uintptr, stk []*profile.Location, labels map[string][]string,
+) bool {
 	for _, loc := range stk {
 		for _, line := range loc.Line {
 			if strings.Contains(line.Function.Name, spec) {
@@ -515,7 +521,9 @@ func stackContains(spec string, count uintptr, stk []*profile.Location, labels m
 
 type sampleMatchFunc func(spec string, count uintptr, stk []*profile.Location, labels map[string][]string) bool
 
-func profileOk(t *testing.T, matches profileMatchFunc, prof *bytes.Buffer, duration time.Duration) (_ *profile.Profile, ok bool) {
+func profileOk(
+	t *testing.T, matches profileMatchFunc, prof *bytes.Buffer, duration time.Duration,
+) (_ *profile.Profile, ok bool) {
 	ok = true
 
 	var samples uintptr
@@ -760,7 +768,9 @@ func TestMathBigDivide(t *testing.T) {
 }
 
 // stackContainsAll matches if all functions in spec (comma-separated) appear somewhere in the stack trace.
-func stackContainsAll(spec string, count uintptr, stk []*profile.Location, labels map[string][]string) bool {
+func stackContainsAll(
+	spec string, count uintptr, stk []*profile.Location, labels map[string][]string,
+) bool {
 	for _, f := range strings.Split(spec, ",") {
 		if !stackContains(f, count, stk, labels) {
 			return false
@@ -1935,6 +1945,7 @@ func BenchmarkGoroutine(b *testing.B) {
 }
 
 func TestGoroutineProfileDebug3Creators(t *testing.T) {
+	t.Skip("cockroach: known flaky on linux/amd64, see https://github.com/cockroachdb/cockroach/issues/165528")
 	// Create synthetic goroutines using the helper
 	cleanup := createSyntheticGoroutines(10, 2)
 	defer cleanup()
@@ -2150,7 +2161,9 @@ func TestEmptyCallStack(t *testing.T) {
 
 // stackContainsLabeled takes a spec like funcname;key=value and matches if the stack has that key
 // and value and has funcname somewhere in the stack.
-func stackContainsLabeled(spec string, count uintptr, stk []*profile.Location, labels map[string][]string) bool {
+func stackContainsLabeled(
+	spec string, count uintptr, stk []*profile.Location, labels map[string][]string,
+) bool {
 	base, kv, ok := strings.Cut(spec, ";")
 	if !ok {
 		panic("no semicolon in key/value spec")
@@ -2860,7 +2873,9 @@ func produceProfileEvents(t *testing.T, depth int) {
 	goroutineDeep(t, depth-4) // -4 for produceProfileEvents, **, chanrecv1, chanrev, gopark
 }
 
-func getProfileStacks(collect func([]runtime.BlockProfileRecord) (int, bool), fileLine bool, pcs bool) []string {
+func getProfileStacks(
+	collect func([]runtime.BlockProfileRecord) (int, bool), fileLine bool, pcs bool,
+) []string {
 	var n int
 	var ok bool
 	var p []runtime.BlockProfileRecord
@@ -3047,7 +3062,9 @@ func TestProfileRecordNullPadding(t *testing.T) {
 	// Not testing ThreadCreateProfile because it is broken, see issue 6104.
 }
 
-func testProfileRecordNullPadding[T runtime.StackRecord | runtime.MemProfileRecord | runtime.BlockProfileRecord](t *testing.T, name string, fn func([]T) (int, bool)) {
+func testProfileRecordNullPadding[T runtime.StackRecord | runtime.MemProfileRecord | runtime.BlockProfileRecord](
+	t *testing.T, name string, fn func([]T) (int, bool),
+) {
 	stack0 := func(sr *T) *[32]uintptr {
 		switch t := any(sr).(type) {
 		case *runtime.StackRecord:

--- a/src/runtime/sizeof_test.go
+++ b/src/runtime/sizeof_test.go
@@ -20,7 +20,7 @@ func TestSizeof(t *testing.T) {
 		_32bit uintptr // size on 32bit platforms
 		_64bit uintptr // size on 64bit platforms
 	}{
-		{runtime.G{}, 296, 456},   // g, but exported for testing
+		{runtime.G{}, 296, 464},   // g, but exported for testing
 		{runtime.Sudog{}, 56, 88}, // sudog, but exported for testing
 	}
 


### PR DESCRIPTION
## Summary

Add a GitHub Actions CI workflow that builds the toolchain from source and runs the full `dist test` suite (588 of 597 tests). Only tests requiring infrastructure not available on a basic runner are skipped:
- `:race` / `:race-external` (need `dist test -race`)
- `testfortran` (needs gfortran)
- `relnote:check` (needs `doc/next/` fragments, absent on release branches)

Also fixes four pre-existing test failures in the fork:
- `TestSizeof`: g struct grew from 456 to 464 bytes (grunningnanos, etc.)
- `TestCopyright`: missing copyright header on `runtime/cockroach.go`
- `cmd/api TestCheck`: fork-specific public APIs not registered in `api/go1.25.txt`
- `TestGoroutineProfileDebug3Creators`: skipped, tracked in https://github.com/cockroachdb/cockroach/issues/165528

## Test plan

- Green CI run: https://github.com/tbg/go/actions/runs/22998566488