### PR TITLE
runtime/pprof: fix TestGoroutineProfileDebug3Creators on linux/amd64

### DIFF
--- a/src/runtime/pprof/pprof_test.go
+++ b/src/runtime/pprof/pprof_test.go
@@ -1945,7 +1945,6 @@ func BenchmarkGoroutine(b *testing.B) {
 }
 
 func TestGoroutineProfileDebug3Creators(t *testing.T) {
-	t.Skip("cockroach: known flaky on linux/amd64, see https://github.com/cockroachdb/cockroach/issues/165528")
 	// Create synthetic goroutines using the helper
 	cleanup := createSyntheticGoroutines(10, 2)
 	defer cleanup()
@@ -1985,9 +1984,11 @@ func TestGoroutineProfileDebug3Creators(t *testing.T) {
 		id := strconv.Itoa(int(s.NumLabel["go::goroutine"][0]))
 		got := s.NumLabel["go::goroutine_created_by"]
 		if createdBy[id] == "" {
-			if len(got) != 0 {
-				t.Fatalf("goroutine %s: got created_by %q, want none", id, got)
-			}
+			// debug=3 may report created_by for goroutines whose
+			// creating function is filtered by showframe in debug=2
+			// (e.g. runtime-internal goroutines). This is expected:
+			// debug=3 provides a superset of debug=2's created_by data.
+			continue
 		} else {
 			if e := createdBy[id]; len(got) != 1 || strconv.Itoa(int(got[0])) != e {
 				t.Fatalf("goroutine %s: got created_by %q, want %q", id, got, e)


### PR DESCRIPTION
The debug=3 protobuf profile unconditionally emits go::goroutine_created_by from parentGoid, while debug=2 text output only prints "created by" when the creating function passes showframe. Allow debug=3 to be a superset of debug=2's created_by data instead of requiring an exact match.